### PR TITLE
[24] Update permissions handling

### DIFF
--- a/gui/irodsBrowser.py
+++ b/gui/irodsBrowser.py
@@ -14,12 +14,6 @@ from PyQt5 import QtGui
 from gui.popupWidgets import irodsCreateCollection
 from utils.utils import walkToDict, getDownloadDir
 
-PERMISIONS_MAP = {
-    'null': 'none',
-    'read object': 'read',
-    'modify object': 'write',
-    'own': 'own',
-}
 
 class irodsBrowser():
     """
@@ -163,7 +157,7 @@ class irodsBrowser():
             acls = self.ic.session.permissions.get(obj)
             self.widget.aclTable.setRowCount(len(acls))
             for row, acl in enumerate(acls):
-                acl_access_name = PERMISIONS_MAP[acl.access_name]
+                acl_access_name = self.ic.permissions[acl.access_name]
                 self.widget.aclTable.setItem(
                     row, 0, QtWidgets.QTableWidgetItem(acl.user_name))
                 self.widget.aclTable.setItem(

--- a/utils/IrodsConnector.py
+++ b/utils/IrodsConnector.py
@@ -90,6 +90,7 @@ class IrodsConnector():
         self.__name__ = 'IrodsConnector'
         self._ienv = None
         self._password = None
+        self._permissions = None
         self._resources = None
         self._session = None
         if ienv is not None:
@@ -194,6 +195,30 @@ class IrodsConnector():
 
     password = property(
         _get_password, _set_password, _del_password, 'iRODS password')
+
+    def _get_permissions(self):
+        """iRODS permissions mapping getter method.
+
+        Returns
+        -------
+        dict
+            Correct permissions mapping for the current server version.
+
+        """
+        if self._permissions is None:
+            self._permissions = {
+                'null': 'none',
+                'read_object': 'read',
+                'modify_object': 'write',
+                'own': 'own',
+            }
+            if self.session.server_version < (4, 3, 0):
+                self._permissions.update(
+                    {'read object': 'read', 'modify object': 'write'})
+        return self._permissions
+
+    permissions = property(
+        _get_permissions, None, None, 'iRODS permissions mapping')
 
     def _get_resources(self):
         """iRODS resources metadata getter method.


### PR DESCRIPTION
iRODS 4.3.0 changes the naming convention for permissions labels in the ICAT.  Allow for transparent handling despite the iRODS verison.