### PR TITLE
[47] Fix selection with PyQt6

### DIFF
--- a/gui/IrodsDataBundle.py
+++ b/gui/IrodsDataBundle.py
@@ -134,14 +134,16 @@ class IrodsDataBundle():
             PyQt6.QtGui.QCursor(PyQt6.QtCore.Qt.CursorShape.WaitCursor))
         self.disable_buttons()
         self.widget.statusLabel.clear()
-        _, coll_name = self.irods_tree_model.get_checked()
-        if coll_name is None:
+        coll_indexes = self.widget.irodsFsTreeView.selectedIndexes()
+        if not len(coll_indexes):
             self.widget.statusLabel.setText(
                 'CREATE ERROR: Something must be selected')
             self.widget.setCursor(
                 PyQt6.QtGui.QCursor(PyQt6.QtCore.Qt.CursorShape.ArrowCursor))
             self.enable_buttons()
             return
+        else:
+            coll_name = self.irods_tree_model.irods_path_from_tree_index(coll_indexes[0])
         if not self.ic.collection_exists(coll_name):
             self.widget.statusLabel.setText(
                 'CREATE ERROR: A collection must be selected')
@@ -213,14 +215,16 @@ class IrodsDataBundle():
             PyQt6.QtGui.QCursor(PyQt6.QtCore.Qt.CursorShape.WaitCursor))
         self.disable_buttons()
         self.widget.statusLabel.clear()
-        idx, obj_path = self.irods_tree_model.get_checked()
-        if obj_path is None:
+        obj_indexes = self.widget.irodsFsTreeView.selectedIndexes()
+        if not len(obj_indexes):
             self.widget.statusLabel.setText(
                 'EXTRACT ERROR: Something must be selected')
             self.widget.setCursor(
                 PyQt6.QtGui.QCursor(PyQt6.QtCore.Qt.CursorShape.ArrowCursor))
             self.enable_buttons()
             return
+        else:
+            obj_path = self.irods_tree_model.irods_path_from_tree_index(obj_indexes[0])
         if not self.ic.dataobject_exists(obj_path):
             self.widget.statusLabel.setText(
                 'EXTRACT ERROR: A data object must be selected')
@@ -230,7 +234,7 @@ class IrodsDataBundle():
             return
         obj_path = pathlib.Path(obj_path)
         file_type = ''.join(obj_path.suffixes)[1:]
-        if not idx or file_type not in EXTENSIONS:
+        if file_type not in EXTENSIONS:
             self.widget.statusLabel.setText(
                 f'EXTRACT ERROR: A bundle file ({", ".join(EXTENSIONS)}) must be selected')
             self.widget.setCursor(
@@ -290,10 +294,11 @@ class IrodsDataBundle():
         self.widget.statusLabel.clear()
         stdout, stderr = stdouterr
         if success:
-            idx, _ = self.irods_tree_model.get_checked()
-            self.widget.statusLabel.setText(f'{operation} STATUS: {stdout}')
-            parent_index = self.irods_tree_model.get_parent_index(idx)
-            self.irods_tree_model.refresh_subtree(parent_index)
+            indexes = self.widget.irodsFsTreeView.selectedIndexes()
+            if len(indexes):
+                self.widget.statusLabel.setText(f'{operation} STATUS: {stdout}')
+                parent_index = self.irods_tree_model.get_parent_index(indexes[0])
+                self.irods_tree_model.refresh_subtree(parent_index)
         else:
             self.widget.statusLabel.setText(f'{operation} ERROR: {stderr}')
 

--- a/gui/IrodsUpDownload.py
+++ b/gui/IrodsUpDownload.py
@@ -4,6 +4,7 @@
 import os
 
 import PyQt6.QtCore
+import PyQt6.QtGui
 import PyQt6.QtWidgets
 
 import gui
@@ -47,14 +48,13 @@ class IrodsUpDownload():
         self._initialize_irods_model()
         self._create_buttons()
         self._create_resource_selector()
-        self._configure_continuous_upload()
         self.upload_window = None
 
     def _initialize_local_model(self):
         """Initialize local QTreeView.
 
         """
-        self.localmodel = gui.checkableFsTree.checkableFsTreeModel(
+        self.localmodel = PyQt6.QtGui.QFileSystemModel(
             self.widget.localFsTreeView)
         self.widget.localFsTreeView.setModel(self.localmodel)
         # Hide all columns except the Name
@@ -67,7 +67,6 @@ class IrodsUpDownload():
             PyQt6.QtCore.QStandardPaths.StandardLocation.HomeLocation)[0]
         index = self.localmodel.setRootPath(home_location)
         self.widget.localFsTreeView.setCurrentIndex(index)
-        self.localmodel.initial_expand()
 
     def _initialize_irods_model(self):
         """Initialize iRODS QTreeView.
@@ -75,14 +74,6 @@ class IrodsUpDownload():
         """
         self.irodsmodel = gui.irodsTreeView.IrodsModel(
             self.ic, self.widget.irodsFsTreeView)
-        # header_labels = [
-        #     self.irodsmodel.zone_path,
-        #     'Level',
-        #     'iRODS ID',
-        #     'parent ID',
-        #     'type',
-        # ]
-        # self.irodsmodel.setHorizontalHeaderLabels(header_labels)
         self.widget.irodsFsTreeView.setModel(self.irodsmodel)
         self.widget.irodsZoneLabel.setText(f'{self.irodsmodel.zone_path}:')
         self.widget.irodsFsTreeView.expanded.connect(
@@ -90,8 +81,6 @@ class IrodsUpDownload():
         self.widget.irodsFsTreeView.clicked.connect(
             self.irodsmodel.refresh_subtree)
         self.irodsmodel.init_tree()
-        # self.widget.irodsFsTreeView.setHeaderHidden(True)
-        # self.widget.irodsFsTreeView.header().setDefaultSectionSize(180)
         self.widget.irodsFsTreeView.setColumnHidden(1, True)
         self.widget.irodsFsTreeView.setColumnHidden(2, True)
         self.widget.irodsFsTreeView.setColumnHidden(3, True)
@@ -109,10 +98,6 @@ class IrodsUpDownload():
         """
         self.widget.UploadButton.clicked.connect(self.upload)
         self.widget.DownloadButton.clicked.connect(self.download)
-        # self.widget.ContUplBut.clicked.connect(self.cont_upload)
-        # For first release hide special buttons
-        self.widget.ContUplBut.setHidden(True)
-        self.widget.uplSetGB_2.setHidden(True)
         self.widget.createFolderButton.clicked.connect(self.create_folder)
         self.widget.createCollButton.clicked.connect(
             self.create_collection)
@@ -132,32 +117,6 @@ class IrodsUpDownload():
             index = self.widget.resourceBox.findText(resources[ridx])
             self.widget.resourceBox.setCurrentIndex(index)
 
-    def _configure_continuous_upload(self):
-        """Configure upload settings.
-
-        """
-        if self.ienv['irods_host'] in UPLOAD_HOSTS:
-            # self.widget.uplSetGB_2.setVisible(True)
-            if REMOVE_LOCAL in self.ienv:
-                self.widget.rLocalcopyCB.setChecked(
-                    self.ienv[REMOVE_LOCAL])
-            if UPLOAD_MODE in self.ienv:
-                upload_mode = self.ienv[UPLOAD_MODE]
-                if upload_mode == "f500":
-                    self.widget.uplF500RB.setChecked(True)
-                elif upload_mode == "meta":
-                    self.widget.uplMetaRB.setChecked(True)
-                else:
-                    self.widget.uplAllRB.setChecked(True)
-            # self.widget.rLocalcopyCB.stateChanged.connect(
-            #     self.save_ui_settings)
-            # self.widget.uplF500RB.toggled.connect(self.save_ui_settings)
-            # self.widget.uplMetaRB.toggled.connect(self.save_ui_settings)
-            # self.widget.uplAllRB.toggled.connect(self.save_ui_settings)
-        else:
-            self.widget.uplSetGB_2.hide()
-            self.widget.ContUplBut.hide()
-
     def enable_buttons(self, enable):
         """Set the state for all buttons.
 
@@ -168,8 +127,6 @@ class IrodsUpDownload():
         """
         self.widget.UploadButton.setEnabled(enable)
         self.widget.DownloadButton.setEnabled(enable)
-        self.widget.ContUplBut.setEnabled(enable)
-        self.widget.uplSetGB_2.setEnabled(enable)
         self.widget.createFolderButton.setEnabled(enable)
         self.widget.createCollButton.setEnabled(enable)
         self.widget.localFsTreeView.setEnabled(enable)
@@ -182,15 +139,6 @@ class IrodsUpDownload():
         PyQt6.QtWidgets.QMessageBox.information(
             self.widget, 'Information', message)
 
-    # FIXME Move these parameters to the iBridges settings.
-    def save_ui_settings(self):
-        """Save the UI settings in the iRODS environment.
-
-        """
-        self.ienv[REMOVE_LOCAL] = self.get_remote_local_copy_state()
-        self.ienv[UPLOAD_MODE] = self.get_upload_mode()
-        utils.utils.saveIenv(self.ienv)
-
     def get_resource(self):
         """Get the resource name from the resource box.
 
@@ -200,7 +148,7 @@ class IrodsUpDownload():
             Current iRODS resource name.
 
         """
-        return self.widget.resourceBox.currentText()
+        return self.widget.resourceBox.currentText().split(' / ')[0]
 
     def get_remote_local_copy_state(self):
         """Get state of remote/local copy button.
@@ -213,48 +161,38 @@ class IrodsUpDownload():
         """
         return self.widget.rLocalcopyCB.isChecked()
 
-    def get_upload_mode(self):
-        """Get upload mode.
-
-        Returns
-        -------
-        str
-            Upload mode.
-
-        """
-        if self.widget.uplF500RB.isChecked():
-            upload_mode = 'f500'
-        elif self.widget.uplMetaRB.isChecked():
-            upload_mode = 'meta'
-        else:
-            upload_mode = 'all'
-        return upload_mode
-
     def create_folder(self):
         """Create a directory/folder on the local filesystem.
 
         """
-        parent = self.localmodel.get_checked()
-        if parent is None:
-            self.widget.errorLabel.setText('No parent folder selected.')
+        indexes = self.widget.localFsTreeView.selectedIndexes()
+        if len(indexes):
+            parent = self.localmodel.filepath(indexes[0])
+            if os.path.isfile(parent):
+                self.widget.errorLabel.setText('No parent folder selected.')
+            else:
+                create_dir_widget = gui.popupWidgets.createDirectory(parent)
+                create_dir_widget.exec()
         else:
-            create_dir_widget = gui.popupWidgets.createDirectory(parent)
-            create_dir_widget.exec()
-            # self.localmodel.initial_expand(previous_item = parent)
+            self.widget.errorLabel.setText('No parent folder selected.')
 
     def create_collection(self):
         """Create collection on the remote iRODS system.
 
         """
-        index, parent = self.irodsmodel.get_checked()
-        if parent is None:
-            self.widget.errorLabel.setText(
-                "No parent collection selected.")
+        indexes = self.widget.irodsFsTreeView.selectedIndexes()
+        if len(indexes):
+            parent = self.irodsmodel.irods_path_from_tree_index(indexes[0])
+            if self.ic.dataobject_exists(parent):
+                self.widget.errorLabel.setText(
+                    "No parent collection selected.")
+            else:
+                create_coll_widget = gui.popupWidgets.irodsCreateCollection(
+                    parent, self.ic)
+                create_coll_widget.exec()
+                self.irodsmodel.refresh_subtree(index)
         else:
-            create_coll_widget = gui.popupWidgets.irodsCreateCollection(
-                parent, self.ic)
-            create_coll_widget.exec()
-            self.irodsmodel.refresh_subtree(index)
+            self.widget.errorLabel.setText("No parent collection selected.")
 
     def upload(self):
         """Upload a file or directory/folder to iRODS and refresh the
@@ -295,9 +233,6 @@ class IrodsUpDownload():
         if success:
             if irods_index is not None:
                 self.irodsmodel.refresh_subtree(irods_index)
-            if self.widget.saveSettings.isChecked():
-                print("FINISH UPLOAD/DOWNLOAD: saving ui parameters.")
-                self.save_ui_settings()
             self.widget.errorLabel.setText(
                 "INFO UPLOAD/DOWLOAD: completed.")
         self.upload_window = None
@@ -333,10 +268,12 @@ class IrodsUpDownload():
         """Get both local and iRODS path from the tree views.
 
         """
-        source = self.localmodel.get_checked()
-        if source is None:
-            return (None, None, None)
-        dest_index, dest_path = self.irodsmodel.get_checked()
-        if dest_index is None or os.path.isfile(dest_path):
-            return (None, None, None)
-        return (source, dest_index, dest_path)
+        src_index = self.widget.localFsTreeView.selectedIndexes()[0]
+        src_path = self.localmodel.filePath(src_index)
+        if src_path is None:
+            return None, None, None
+        dst_index = self.widget.irodsFsTreeView.selectedIndexes()[0]
+        dst_path = self.irodsmodel.irods_path_from_tree_index(dst_index)
+        if dst_index is None:
+            return None, None, None
+        return src_path, dst_index, dst_path

--- a/gui/irodsCreateTicket.py
+++ b/gui/irodsCreateTicket.py
@@ -33,8 +33,11 @@ class irodsCreateTicket():
         self.widget.createTicketButton.setEnabled(False)
 
         #gather info
-        idx, path = self.irodsmodel.get_checked()
-        if path == None or self.ic.session.data_objects.exists(path):
+        indexes = self.widget.irodsFsTreeView.selectedIndexes()
+        path = ''
+        if len(indexes):
+            path = self.irodsmodel.irods_path_from_tree_index(indexes[0])
+        if not self.ic.session.collections.exists(path):
             self.widget.infoLabel.setText("ERROR: Please select a collection.")
             self.widget.setCursor(QtGui.QCursor(QtCore.Qt.CursorShape.ArrowCursor))
             self.widget.createTicketButton.setEnabled(True)

--- a/gui/ui-files/irodsLogin.ui
+++ b/gui/ui-files/irodsLogin.ui
@@ -24,16 +24,19 @@
 {
 	background-color: rgb(54, 54, 54);
 	color: rgb(86, 184, 139);
+	border-color: rgb(217, 174, 23);
 }
 
 QLineEdit
 {
 	background-color: rgb(85, 87, 83);
+	border-color: rgb(217, 174, 23);
 }
 
 QRadioButton
 {
 	border-bottom-color: rgb(206, 92, 0);
+    selection-color: rgb(217, 174, 23);
 }
 
 QLabel#passError, QLabel#envError, QLabel#icommandsError
@@ -56,7 +59,6 @@ QLabel#passError, QLabel#envError, QLabel#icommandsError
       <property name="font">
        <font>
         <pointsize>20</pointsize>
-        <weight>75</weight>
         <bold>true</bold>
        </font>
       </property>
@@ -236,7 +238,6 @@ QLabel#passError, QLabel#envError, QLabel#icommandsError
       <property name="font">
        <font>
         <pointsize>13</pointsize>
-        <weight>75</weight>
         <bold>true</bold>
        </font>
       </property>

--- a/gui/ui-files/tabBrowser.ui
+++ b/gui/ui-files/tabBrowser.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1278</width>
-    <height>781</height>
+    <height>807</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,34 +18,37 @@
 {
 	color: rgb(86, 184, 139);
 	background-color: rgb(54, 54, 54);
+    border-color: rgb(86, 184, 139);
 	selection-background-color: rgb(58, 152, 112);
 }
 
 QTabWidget
 {
-background-color: rgb(85, 87, 83);
+    background-color: rgb(85, 87, 83);
 }
 
 QTableWidget
 {
-background-color: rgb(85, 87, 83);
-selection-background-color: rgb(58, 152, 112);
+    background-color: rgb(85, 87, 83);
+    selection-background-color: rgb(58, 152, 112);
+    border-color: rgb(86, 184, 139);
 }
 
 QLabel#errorLabel
 {
-color: rgb(217, 174, 23);
+    color: rgb(217, 174, 23);
 }
 
 QLineEdit#inputPath
 {
-background-color: rgb(85, 87, 83);
+    background-color: rgb(85, 87, 83);
+    border-color: rgb(86, 184, 139);
 }
 
 QPushButton#dataDeleteButton
 {
-background-color: rgb(164, 0, 0);
-color: rgb(46, 52, 54);
+    background-color: rgb(164, 0, 0);
+    color: rgb(46, 52, 54);
 }</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -87,7 +90,6 @@ color: rgb(46, 52, 54);
        <property name="font">
         <font>
          <pointsize>16</pointsize>
-         <weight>75</weight>
          <bold>true</bold>
         </font>
        </property>
@@ -225,7 +227,6 @@ color: rgb(46, 52, 54);
      <widget class="QWidget" name="preview">
       <property name="font">
        <font>
-        <weight>50</weight>
         <bold>false</bold>
        </font>
       </property>
@@ -315,7 +316,6 @@ color: rgb(46, 52, 54);
           <widget class="QPushButton" name="metaUpdateButton">
            <property name="font">
             <font>
-             <weight>75</weight>
              <bold>true</bold>
             </font>
            </property>
@@ -335,7 +335,6 @@ color: rgb(46, 52, 54);
           <widget class="QPushButton" name="metaDeleteButton">
            <property name="font">
             <font>
-             <weight>75</weight>
              <bold>true</bold>
             </font>
            </property>
@@ -352,7 +351,6 @@ color: rgb(46, 52, 54);
            <property name="font">
             <font>
              <pointsize>20</pointsize>
-             <weight>75</weight>
              <bold>true</bold>
             </font>
            </property>
@@ -365,7 +363,6 @@ color: rgb(46, 52, 54);
           <widget class="QPushButton" name="metaAddButton">
            <property name="font">
             <font>
-             <weight>75</weight>
              <bold>true</bold>
             </font>
            </property>
@@ -453,7 +450,6 @@ color: rgb(46, 52, 54);
           <widget class="QPushButton" name="aclAddButton">
            <property name="font">
             <font>
-             <weight>75</weight>
              <bold>true</bold>
             </font>
            </property>
@@ -467,7 +463,6 @@ color: rgb(46, 52, 54);
            <property name="font">
             <font>
              <pointsize>20</pointsize>
-             <weight>75</weight>
              <bold>true</bold>
             </font>
            </property>
@@ -637,7 +632,6 @@ color: rgb(46, 52, 54);
            <property name="font">
             <font>
              <pointsize>13</pointsize>
-             <weight>75</weight>
              <bold>true</bold>
             </font>
            </property>

--- a/gui/ui-files/tabDataBundle.ui
+++ b/gui/ui-files/tabDataBundle.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>640</width>
-    <height>502</height>
+    <height>532</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,19 +16,19 @@
   <property name="styleSheet">
    <string notr="true">QWidget
 {
- color: rgb(86, 184, 139);
- background-color: rgb(54, 54, 54);
- selection-background-color: rgb(58, 152, 112);
+    color: rgb(86, 184, 139);
+    background-color: rgb(54, 54, 54);
+    selection-background-color: rgb(58, 152, 112);
 }
 
 QTreeView
 {
- background-color: rgb(85, 87, 83);
+    background-color: rgb(85, 87, 83);
 }
 
 QLabel#statusLabel
 {
- color: rgb(217, 174, 23);
+    color: rgb(217, 174, 23);
 }
 </string>
   </property>
@@ -38,7 +38,6 @@ QLabel#statusLabel
      <property name="font">
       <font>
        <pointsize>13</pointsize>
-       <weight>75</weight>
        <bold>true</bold>
       </font>
      </property>
@@ -81,7 +80,7 @@ QLabel#statusLabel
         <set>QAbstractItemView::NoEditTriggers</set>
        </property>
        <property name="selectionMode">
-        <enum>QAbstractItemView::NoSelection</enum>
+        <enum>QAbstractItemView::SingleSelection</enum>
        </property>
       </widget>
      </item>
@@ -138,7 +137,6 @@ QLabel#statusLabel
         <widget class="QPushButton" name="createButton">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -151,7 +149,6 @@ QLabel#statusLabel
         <widget class="QPushButton" name="extractButton">
          <property name="font">
           <font>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>

--- a/gui/ui-files/tabELNData.ui
+++ b/gui/ui-files/tabELNData.ui
@@ -278,7 +278,7 @@ QLabel#errorLabel{
         <set>QAbstractItemView::NoEditTriggers</set>
        </property>
        <property name="selectionMode">
-        <enum>QAbstractItemView::NoSelection</enum>
+        <enum>QAbstractItemView::SingleSelection</enum>
        </property>
       </widget>
      </item>
@@ -330,7 +330,6 @@ QLabel#errorLabel{
            <property name="font">
             <font>
              <pointsize>13</pointsize>
-             <weight>75</weight>
              <bold>true</bold>
             </font>
            </property>

--- a/gui/ui-files/tabTicketCreate.ui
+++ b/gui/ui-files/tabTicketCreate.ui
@@ -122,7 +122,6 @@ QLabel#infoLabel{
          <property name="font">
           <font>
            <pointsize>13</pointsize>
-           <weight>75</weight>
            <bold>true</bold>
           </font>
          </property>
@@ -204,7 +203,7 @@ QLabel#infoLabel{
         <set>QAbstractItemView::NoEditTriggers</set>
        </property>
        <property name="selectionMode">
-        <enum>QAbstractItemView::NoSelection</enum>
+        <enum>QAbstractItemView::SingleSelection</enum>
        </property>
       </widget>
      </item>

--- a/gui/ui-files/tabUpDownload.ui
+++ b/gui/ui-files/tabUpDownload.ui
@@ -55,7 +55,7 @@ QLabel#errorLabel
      <height>771</height>
     </rect>
    </property>
-   <layout class="QVBoxLayout" name="verticalLayout_11" stretch="2,0,0,0,1">
+   <layout class="QVBoxLayout" name="verticalLayout_11" stretch="2,0,0">
     <property name="sizeConstraint">
      <enum>QLayout::SetDefaultConstraint</enum>
     </property>
@@ -80,7 +80,6 @@ QLabel#errorLabel
           <property name="font">
            <font>
             <pointsize>13</pointsize>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -134,7 +133,7 @@ QLabel#errorLabel
            <set>QAbstractItemView::NoEditTriggers</set>
           </property>
           <property name="selectionMode">
-           <enum>QAbstractItemView::NoSelection</enum>
+           <enum>QAbstractItemView::SingleSelection</enum>
           </property>
           <property name="headerHidden">
            <bool>true</bool>
@@ -208,44 +207,6 @@ QLabel#errorLabel
         </item>
         <item>
          <layout class="QGridLayout" name="gridLayout_7">
-          <item row="0" column="2">
-           <spacer name="horizontalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="5" column="1">
-           <widget class="QPushButton" name="ContUplBut">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>100</width>
-              <height>70</height>
-             </size>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="iconSize">
-             <size>
-              <width>50</width>
-              <height>50</height>
-             </size>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="1">
            <widget class="QPushButton" name="UploadButton">
             <property name="minimumSize">
@@ -268,6 +229,19 @@ QLabel#errorLabel
              </size>
             </property>
            </widget>
+          </item>
+          <item row="0" column="2">
+           <spacer name="horizontalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
           <item row="3" column="1">
            <widget class="QPushButton" name="DownloadButton">
@@ -311,19 +285,6 @@ QLabel#errorLabel
             </property>
            </spacer>
           </item>
-          <item row="4" column="1">
-           <spacer name="verticalSpacer_10">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
           <item row="1" column="1">
            <spacer name="verticalSpacer_11">
             <property name="orientation">
@@ -341,22 +302,6 @@ QLabel#errorLabel
            </spacer>
           </item>
          </layout>
-        </item>
-        <item>
-         <spacer name="verticalSpacer_22">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Minimum</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>80</height>
-           </size>
-          </property>
-         </spacer>
         </item>
         <item>
          <spacer name="verticalSpacer_12">
@@ -399,7 +344,6 @@ QLabel#errorLabel
           <property name="font">
            <font>
             <pointsize>13</pointsize>
-            <weight>75</weight>
             <bold>true</bold>
            </font>
           </property>
@@ -469,7 +413,7 @@ QLabel#errorLabel
            <set>QAbstractItemView::NoEditTriggers</set>
           </property>
           <property name="selectionMode">
-           <enum>QAbstractItemView::NoSelection</enum>
+           <enum>QAbstractItemView::SingleSelection</enum>
           </property>
           <property name="headerHidden">
            <bool>true</bool>
@@ -501,90 +445,6 @@ QLabel#errorLabel
       <property name="text">
        <string/>
       </property>
-     </widget>
-    </item>
-    <item>
-     <spacer name="verticalSpacer">
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
-      </property>
-      <property name="sizeHint" stdset="0">
-       <size>
-        <width>20</width>
-        <height>40</height>
-       </size>
-      </property>
-     </spacer>
-    </item>
-    <item>
-     <widget class="QGroupBox" name="uplSetGB_2">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>0</width>
-        <height>50</height>
-       </size>
-      </property>
-      <property name="styleSheet">
-       <string notr="true"/>
-      </property>
-      <property name="title">
-       <string>Upload settings</string>
-      </property>
-      <layout class="QGridLayout" name="gridLayout_4">
-       <item row="0" column="1">
-        <widget class="QRadioButton" name="uplMetaRB">
-         <property name="text">
-          <string>Metadata based</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QRadioButton" name="uplAllRB">
-         <property name="text">
-          <string>All files</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QCheckBox" name="rLocalcopyCB">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>Remove  local copy</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QRadioButton" name="uplF500RB">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>F500</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QCheckBox" name="saveSettings">
-         <property name="text">
-          <string>Save Settings for next session</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
      </widget>
     </item>
    </layout>

--- a/utils/IrodsConnector.py
+++ b/utils/IrodsConnector.py
@@ -239,7 +239,7 @@ class IrodsConnector():
                 name, parent, status, context = item.values()
                 free_space = 0
                 if parent is None:
-                    free_space = self.get_free_space(name)
+                    free_space = self.get_free_space(name, multiplier=MULTIPLIER)
                 metadata = {
                     'parent': parent,
                     'status': status,
@@ -668,7 +668,8 @@ class IrodsConnector():
                 resc_name, exc_info=True)
             raise FreeSpaceNotSet(
                 f'RESOURCE ERROR: Resource "free_space" is not set for {resc_name}.')
-        return space
+        # For convenience, free_space is stored multiplied by MULTIPLIER.
+        return int(space / MULTIPLIER)
 
     def get_free_space(self, resc_name, multiplier=MULTIPLIER):
         """Determine free space in a resource hierarchy.


### PR DESCRIPTION
Address problems in Issue #47 where checkboxes no longer were selectable.  Now use row selection instead.  Opens door to multi-row selection in the future.