### PR TITLE
[46] Re-enable browser permissions

### DIFF
--- a/gui/IrodsBrowser.py
+++ b/gui/IrodsBrowser.py
@@ -151,13 +151,16 @@ class IrodsBrowser:
         self.widget.aclTable.setRowCount(0)
         self.widget.aclUserField.clear()
         self.widget.aclZoneField.clear()
-        self.widget.aclBox.setCurrentText("----")
+        self.widget.aclBox.setCurrentText('')
         obj = None
         if self.ic.collection_exists(obj_path):
             obj = self.ic.session.collections.get(obj_path)
         elif self.ic.dataobject_exists(obj_path):
             obj = self.ic.session.data_objects.get(obj_path)
         if obj is not None:
+            inheritance = ''
+            if self.ic.is_collection(obj):
+                inheritance = obj.inheritance
             acls = self.ic.get_permissions(obj=obj)
             self.widget.aclTable.setRowCount(len(acls))
             for row, acl in enumerate(acls):
@@ -168,6 +171,8 @@ class IrodsBrowser:
                     row, 1, PyQt6.QtWidgets.QTableWidgetItem(acl.user_zone))
                 self.widget.aclTable.setItem(
                     row, 2, PyQt6.QtWidgets.QTableWidgetItem(acl_access_name))
+                self.widget.aclTable.setItem(
+                    row, 3, PyQt6.QtWidgets.QTableWidgetItem(str(inheritance)))
         self.widget.aclTable.resizeColumnsToContents()
 
     def _fill_metadata_tab(self, obj_path):
@@ -469,7 +474,7 @@ class IrodsBrowser:
         self._clear_error_label()
         self.widget.aclUserField.clear()
         self.widget.aclZoneField.clear()
-        self.widget.aclBox.setCurrentText("----")
+        self.widget.aclBox.setCurrentText('')
         row = index.row()
         user_name = self.widget.aclTable.item(row, 0).text()
         user_zone = self.widget.aclTable.item(row, 1).text()

--- a/gui/IrodsBrowser.py
+++ b/gui/IrodsBrowser.py
@@ -488,20 +488,25 @@ class IrodsBrowser:
             self.widget.errorLabel.setText('Please select an object first!')
             return
         self.widget.errorLabel.clear()
-        errors = []
+        errors = {}
         obj_path, obj_name = self._get_object_path_name(self.current_browser_row)
         obj_path = iRODSPath(obj_path, obj_name)
         user_name = self.widget.aclUserField.text()
         if not user_name:
-            errors.append('User name')
+            errors['User name'] = None
         user_zone = self.widget.aclZoneField.text()
-        if not user_zone:
-            errors.append('Zone name')
         acc_name = self.widget.aclBox.currentText()
         if not acc_name:
-            errors.append('Access name')
+            errors['Access name'] = None
+        if acc_name.endswith('inherit'):
+            if self.ic.dataobject_exists(obj_path):
+                self.widget.errorLabel.setText(
+                    'WARNING: (no)inherit is not applicable to data objects')
+                return
+            errors.pop('User name', None)
         if len(errors):
-            self.widget.errorLabel.setText(f'Missing input: {", ".join(errors)}')
+            self.widget.errorLabel.setText(
+                f'Missing input: {", ".join(errors.keys())}')
             return
         recursive = self.widget.aclRecurseBox.currentText() == 'True'
         admin = self.widget.aclAdminBox.isChecked()

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -4,7 +4,7 @@ from . import checkableFsTree
 from . import continousUpload
 from . import dataTransfer
 from . import elabUpload
-from . import irodsBrowser
+from . import IrodsBrowser
 from . import irodsCreateTicket
 from . import IrodsDataBundle
 from . import irodsInfo

--- a/gui/mainmenu.py
+++ b/gui/mainmenu.py
@@ -13,7 +13,7 @@ from PyQt6.uic import loadUi
 from PyQt6 import QtCore
 from PyQt6 import QtGui
 
-from gui.irodsBrowser import irodsBrowser
+from gui.IrodsBrowser import IrodsBrowser
 from gui.elabUpload import elabUpload
 from gui.irodsSearch import irodsSearch
 from gui.IrodsUpDownload import IrodsUpDownload
@@ -54,7 +54,7 @@ class mainmenu(QMainWindow):
             # tabBrowser needed for Search
             self.browserWidget = loadUi('gui/ui-files/tabBrowser.ui')
             self.tabWidget.addTab(self.browserWidget, 'Browser')
-            self.irodsBrowser = irodsBrowser(self.browserWidget, ic)
+            self.irodsBrowser = IrodsBrowser(self.browserWidget, ic)
             # Optional tabs
             if ('ui_tabs' in ienv) and (ienv['ui_tabs'] != []):
                 # Setup up/download tab, index 1

--- a/gui/ui-files/tabBrowser.ui
+++ b/gui/ui-files/tabBrowser.ui
@@ -470,7 +470,7 @@ QPushButton#dataDeleteButton
          <item row="4" column="1">
           <widget class="QLabel" name="label_8">
            <property name="text">
-            <string>Zone name</string>
+            <string>Zone name (optional)</string>
            </property>
           </widget>
          </item>

--- a/gui/ui-files/tabBrowser.ui
+++ b/gui/ui-files/tabBrowser.ui
@@ -422,7 +422,7 @@ QPushButton#dataDeleteButton
          </property>
          <column>
           <property name="text">
-           <string>User name</string>
+           <string>User</string>
           </property>
          </column>
          <column>
@@ -432,32 +432,13 @@ QPushButton#dataDeleteButton
          </column>
          <column>
           <property name="text">
-           <string>Permission type</string>
+           <string>Access</string>
           </property>
          </column>
         </widget>
        </item>
        <item>
         <layout class="QGridLayout" name="gridLayout_4">
-         <item row="4" column="2">
-          <widget class="QLabel" name="label_10">
-           <property name="text">
-            <string>Permission type</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="3">
-          <widget class="QPushButton" name="aclAddButton">
-           <property name="font">
-            <font>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="text">
-            <string>Add</string>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="0">
           <widget class="QLabel" name="label_11">
            <property name="font">
@@ -471,10 +452,30 @@ QPushButton#dataDeleteButton
            </property>
           </widget>
          </item>
-         <item row="4" column="3">
-          <widget class="QLabel" name="label_7">
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_13">
            <property name="text">
-            <string>Recursive</string>
+            <string>User name</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLineEdit" name="aclUserField"/>
+         </item>
+         <item row="4" column="1">
+          <widget class="QLabel" name="label_8">
+           <property name="text">
+            <string>Zone name</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QLineEdit" name="aclZoneField"/>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="label_10">
+           <property name="text">
+            <string>Access name</string>
            </property>
           </widget>
          </item>
@@ -482,7 +483,7 @@ QPushButton#dataDeleteButton
           <widget class="QComboBox" name="aclBox">
            <item>
             <property name="text">
-             <string>----</string>
+             <string/>
             </property>
            </item>
            <item>
@@ -505,20 +506,22 @@ QPushButton#dataDeleteButton
              <string>own</string>
             </property>
            </item>
+           <item>
+            <property name="text">
+             <string>inherit</string>
+            </property>
+           </item>
           </widget>
          </item>
-         <item row="6" column="0">
-          <widget class="QLineEdit" name="aclUserField"/>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="label_13">
+         <item row="4" column="3">
+          <widget class="QLabel" name="label_7">
            <property name="text">
-            <string>User name</string>
+            <string>Recursive</string>
            </property>
           </widget>
          </item>
          <item row="6" column="3">
-          <widget class="QComboBox" name="recurseBox">
+          <widget class="QComboBox" name="aclRecurseBox">
            <item>
             <property name="text">
              <string>False</string>
@@ -529,6 +532,34 @@ QPushButton#dataDeleteButton
              <string>True</string>
             </property>
            </item>
+          </widget>
+         </item>
+         <item row="4" column="4">
+          <widget class="QCheckBox" name="aclAdminBox">
+           <property name="cursor">
+            <cursorShape>PointingHandCursor</cursorShape>
+           </property>
+           <property name="styleSheet">
+            <string notr="true"/>
+           </property>
+           <property name="text">
+            <string>Admin</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="4">
+          <widget class="QPushButton" name="aclAddButton">
+           <property name="font">
+            <font>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>Add/Update</string>
+           </property>
           </widget>
          </item>
          <item row="8" column="0">
@@ -543,16 +574,6 @@ QPushButton#dataDeleteButton
             </size>
            </property>
           </spacer>
-         </item>
-         <item row="6" column="1">
-          <widget class="QLineEdit" name="aclZoneField"/>
-         </item>
-         <item row="4" column="1">
-          <widget class="QLabel" name="label_8">
-           <property name="text">
-            <string>UserZone</string>
-           </property>
-          </widget>
          </item>
         </layout>
        </item>

--- a/gui/ui-files/tabBrowser.ui
+++ b/gui/ui-files/tabBrowser.ui
@@ -435,6 +435,11 @@ QPushButton#dataDeleteButton
            <string>Access</string>
           </property>
          </column>
+         <column>
+          <property name="text">
+           <string>Inherit</string>
+          </property>
+         </column>
         </widget>
        </item>
        <item>
@@ -509,6 +514,11 @@ QPushButton#dataDeleteButton
            <item>
             <property name="text">
              <string>inherit</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>noinherit</string>
             </property>
            </item>
           </widget>

--- a/utils/IrodsConnector.py
+++ b/utils/IrodsConnector.py
@@ -434,7 +434,7 @@ class IrodsConnector():
         print('WARNING -- `obj` must be or `path` must resolve into, a collection or data object')
         return []
 
-    def set_permissions(self, perm, path, user, zone, recursive=False, admin=False):
+    def set_permissions(self, perm, path, user='', zone='', recursive=False, admin=False):
         """Set permissions (ACL) for an iRODS collection or data object.
 
         Parameters

--- a/utils/IrodsConnector.py
+++ b/utils/IrodsConnector.py
@@ -434,7 +434,7 @@ class IrodsConnector():
         print('WARNING -- `obj` must be or `path` must resolve into, a collection or data object')
         return []
 
-    def set_permissions(self, perm, path, user, zone, recursive=False):
+    def set_permissions(self, perm, path, user, zone, recursive=False, admin=False):
         """Set permissions (ACL) for an iRODS collection or data object.
 
         Parameters
@@ -449,12 +449,14 @@ class IrodsConnector():
             Name of user's zone.
         recursive : bool
             Apply ACL to all children of `path`.
+        admin : bool
+            If a 'rodsadmin' apply ACL for another user.
 
         """
         acl = irods.access.iRODSAccess(perm, path, user, zone)
         try:
-            if self.session.collections.exists(path):
-                self.session.permissions.set(acl, recursive=recursive)
+            if self.dataobject_exists(path) or self.collection_exists(path):
+                self.session.permissions.set(acl, recursive=recursive, admin=admin)
         except irods.exception.CAT_INVALID_USER as ciu:
             print(f'{RED}ACL ERROR: user unknown{DEFAULT}')
             raise ciu


### PR DESCRIPTION
Remove restriction to allow only admin-types to modify metadata.  Add support in the Permissions view for inheritance and admin mode.